### PR TITLE
Fix typo in add_subdirectory

### DIFF
--- a/ccnx/forwarder/athena/CMakeLists.txt
+++ b/ccnx/forwarder/athena/CMakeLists.txt
@@ -53,7 +53,7 @@ if ( UNIX )
   execute_process(COMMAND whoami OUTPUT_VARIABLE USER 
 	    OUTPUT_STRIP_TRAILING_WHITESPACE)
   if ( ${USER} STREQUAL "root" )
-	add_subdirector(platform/darwin/test)
+	add_subdirectory(platform/darwin/test)
 	add_subdirectory(platform/linux/test)
   endif()
 endif()


### PR DESCRIPTION
* Fix typo in 'add_subdirectory' cmake command, which causes build process to fail when running as root. 